### PR TITLE
Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* linguist-language=C++


### PR DESCRIPTION
People should be fully aware of the language used in the project
And other languages have their own highlights, which should not be set to C++'s highlights

